### PR TITLE
Support BACKSTAGE_TOKEN_FILE for externally-rotated bearer tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`BACKSTAGE_TOKEN_FILE` environment variable**: read the bearer token from a file instead of an env literal. The file is re-read on every outgoing request, so external rotation (e.g. by a sidecar refresh process) takes effect without restarting the server. Takes precedence over `BACKSTAGE_TOKEN` when both are set.
+
 ### Fixed
 
 - **Authentication and Security**: Implemented comprehensive authentication system with AuthManager supporting multiple auth methods (Bearer, OAuth, API keys, Service accounts), automatic token refresh, rate limiting, security auditing, and input sanitization. Added security interceptors to API client and audit logging for all operations.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ The server requires environment variables for Backstage API access:
 
 Choose one of the following authentication methods:
 
-- `BACKSTAGE_TOKEN` - Bearer token for API access
+- `BACKSTAGE_TOKEN` - Bearer token for API access (static)
+- `BACKSTAGE_TOKEN_FILE` - Path to a file containing the bearer token. Re-read on every request, so the token can be rotated externally without restarting the server. Takes precedence over `BACKSTAGE_TOKEN` when both are set.
 - `BACKSTAGE_CLIENT_ID`, `BACKSTAGE_CLIENT_SECRET`, `BACKSTAGE_TOKEN_URL` - OAuth credentials
 - `BACKSTAGE_API_KEY` - API key authentication
 - `BACKSTAGE_SERVICE_ACCOUNT_KEY` - Service account key

--- a/src/auth/auth-manager.test.ts
+++ b/src/auth/auth-manager.test.ts
@@ -24,6 +24,7 @@ jest.mock('../utils/core/logger.js', () => ({
 }));
 
 import axios, { AxiosResponse } from 'axios';
+import { writeFileSync, unlinkSync } from 'fs';
 
 import { AuthConfig, TokenInfo } from '../types/auth.js';
 import { AuthManager } from './auth-manager.js';
@@ -152,6 +153,53 @@ describe('AuthManager', () => {
         authManager = new AuthManager(config);
 
         await expect(authManager.getAuthorizationHeader()).rejects.toThrow('Bearer token not configured');
+      });
+
+      describe('token file', () => {
+        const tokenFilePath = '/tmp/test-backstage-token.txt';
+
+        afterEach(() => {
+          try { unlinkSync(tokenFilePath); } catch {}
+        });
+
+        it('should read token from file', async () => {
+          writeFileSync(tokenFilePath, 'file-token\n');
+          config = { type: 'bearer', tokenFile: tokenFilePath };
+          authManager = new AuthManager(config);
+
+          const header = await authManager.getAuthorizationHeader();
+          expect(header).toBe('Bearer file-token');
+        });
+
+        it('should read updated token on next call', async () => {
+          writeFileSync(tokenFilePath, 'token-v1');
+          config = { type: 'bearer', tokenFile: tokenFilePath };
+          authManager = new AuthManager(config);
+
+          const header1 = await authManager.getAuthorizationHeader();
+          expect(header1).toBe('Bearer token-v1');
+
+          writeFileSync(tokenFilePath, 'token-v2');
+          (authManager as unknown as AuthManagerWithPrivate).tokenInfo = undefined;
+
+          const header2 = await authManager.getAuthorizationHeader();
+          expect(header2).toBe('Bearer token-v2');
+        });
+
+        it('should throw error if token file does not exist', async () => {
+          config = { type: 'bearer', tokenFile: '/nonexistent/path.txt' };
+          authManager = new AuthManager(config);
+
+          await expect(authManager.getAuthorizationHeader()).rejects.toThrow('ENOENT');
+        });
+
+        it('should throw error if token file is empty', async () => {
+          writeFileSync(tokenFilePath, '');
+          config = { type: 'bearer', tokenFile: tokenFilePath };
+          authManager = new AuthManager(config);
+
+          await expect(authManager.getAuthorizationHeader()).rejects.toThrow('Bearer token not configured');
+        });
       });
     });
 

--- a/src/auth/auth-manager.ts
+++ b/src/auth/auth-manager.ts
@@ -73,6 +73,10 @@ export class AuthManager {
    */
   private isTokenValid(): boolean {
     if (isNullOrUndefined(this.tokenInfo)) return false;
+
+    // Always re-read file-based tokens (they may have been refreshed externally)
+    if (isNonEmptyString(this.config.tokenFile)) return false;
+
     if (isNullOrUndefined(this.tokenInfo.expiresAt)) return true;
 
     // Refresh 5 minutes before expiry

--- a/src/auth/auth-manager.ts
+++ b/src/auth/auth-manager.ts
@@ -13,6 +13,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 import axios, { AxiosResponse } from 'axios';
+import { readFileSync } from 'fs';
 
 import { AuthConfig, TokenInfo } from '../types/auth.js';
 import { isNonEmptyString, isNullOrUndefined, isNumber } from '../utils/core/guards.js';
@@ -132,11 +133,17 @@ export class AuthManager {
    * @private
    */
   private async handleBearerToken(): Promise<TokenInfo> {
-    if (!isNonEmptyString(this.config.token)) {
+    let token = this.config.token;
+
+    if (isNonEmptyString(this.config.tokenFile)) {
+      token = readFileSync(this.config.tokenFile, 'utf-8').trim();
+    }
+
+    if (!isNonEmptyString(token)) {
       throw new ConfigurationError('Bearer token not configured');
     }
     return {
-      accessToken: this.config.token,
+      accessToken: token,
       tokenType: 'Bearer',
     };
   }

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -27,6 +27,7 @@ describe('server', () => {
     delete process.env.BACKSTAGE_TOKEN_URL;
     delete process.env.BACKSTAGE_API_KEY;
     delete process.env.BACKSTAGE_SERVICE_ACCOUNT_KEY;
+    delete process.env.BACKSTAGE_TOKEN_FILE;
   });
 
   describe('buildAuthConfig', () => {
@@ -89,6 +90,25 @@ describe('server', () => {
 
     it('should throw error when no auth config', () => {
       expect(() => buildAuthConfig()).toThrow('No valid authentication configuration found');
+    });
+
+    it('should build bearer auth config with token file', () => {
+      process.env.BACKSTAGE_TOKEN_FILE = '/path/to/token.txt';
+      const result = buildAuthConfig();
+      expect(result).toEqual({
+        type: 'bearer',
+        tokenFile: '/path/to/token.txt',
+      });
+    });
+
+    it('should prioritize token file over static token', () => {
+      process.env.BACKSTAGE_TOKEN_FILE = '/path/to/token.txt';
+      process.env.BACKSTAGE_TOKEN = 'static-token';
+      const result = buildAuthConfig();
+      expect(result).toEqual({
+        type: 'bearer',
+        tokenFile: '/path/to/token.txt',
+      });
     });
 
     it('should throw error for incomplete oauth', () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -95,6 +95,7 @@ export async function startServer(): Promise<void> {
  * @throws ConfigurationError if no valid authentication configuration is found
  */
 export function buildAuthConfig(): AuthConfig {
+  const tokenFile = process.env.BACKSTAGE_TOKEN_FILE;
   const token = process.env.BACKSTAGE_TOKEN;
   const clientId = process.env.BACKSTAGE_CLIENT_ID;
   const clientSecret = process.env.BACKSTAGE_CLIENT_SECRET;
@@ -102,6 +103,9 @@ export function buildAuthConfig(): AuthConfig {
   const apiKey = process.env.BACKSTAGE_API_KEY;
   const serviceAccountKey = process.env.BACKSTAGE_SERVICE_ACCOUNT_KEY;
 
+  if (isNonEmptyString(tokenFile)) {
+    return { type: 'bearer', tokenFile };
+  }
   if (isNonEmptyString(token)) {
     return { type: 'bearer', token };
   }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -15,6 +15,7 @@
 export interface AuthConfig {
   type: 'bearer' | 'oauth' | 'api-key' | 'service-account';
   token?: string;
+  tokenFile?: string;
   clientId?: string;
   clientSecret?: string;
   tokenUrl?: string;


### PR DESCRIPTION
## Summary
- Add `BACKSTAGE_TOKEN_FILE` env var that points to a file containing the bearer token
- Re-read the file on every request so externally rotated tokens are picked up without restarting the server
- Takes precedence over `BACKSTAGE_TOKEN` when both are set

## Motivation
Some Backstage deployments use short-lived bearer tokens that are refreshed by an out-of-process tool (e.g. an SSO refresh helper writing to a local file). Without file-based reads, the MCP server has to be restarted whenever the token rotates.

## Changes
- `src/types/auth.ts` — add `tokenFile?: string` to `AuthConfig`
- `src/auth/auth-manager.ts` — read token from file when `tokenFile` is set; treat file-based tokens as always stale so `isTokenValid` triggers a re-read on every request
- `src/server.ts` — wire `BACKSTAGE_TOKEN_FILE` into `buildAuthConfig`

## Test plan
- [x] `yarn test` — new unit tests cover file-based reads and re-read behavior
- [x] `yarn lint`, `yarn build` clean
- [ ] Local smoke test with a token file rotated externally — token picked up on next MCP tool call without server restart